### PR TITLE
Voltage monitoring afgerond

### DIFF
--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
@@ -33,12 +33,6 @@
 // uint16_t variable to store the analog converted value
 volatile uint16_t ADC_Waarde = 0;
 
-ISR(ADC_vect)
-{
-	// Save ADC value
-	ADC_Waarde = ADC;
-}
-
 void initVoltageMonitoring(void)
 {
 	// Initialize the ADC peripheral
@@ -65,5 +59,11 @@ uint16_t getVoltage(void)
 long map(long x, long in_min, long in_max, long out_min, long out_max)
 {
 	return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+ISR(ADC_vect)
+{
+	// Save ADC value
+	ADC_Waarde = ADC;
 }
 /* ---------------------------------------------------- End of Voltage_monitoring.c ---------------------------------------------------- */

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
@@ -4,26 +4,31 @@
  * Created: 14-12-2023 09:15:25
  *  Author: Julian Janssen
  *
- *	(R2/(R1+R2)*v) = otu
- * (1500/(1200+1500))*9 = 5
+ * ===== TEST RESULTS =====
+ * Battery voltage:			7,7 volt
+ * Voltage on divider:		4,01 volt
+ * AVR measure (uint16_t):	398 
+ * AVR measure (REAL):		3,98 volt
  *
  *
  */ 
 #include "Voltage_monitoring.h"
 
-#ifndef  AVR
+// Check if these libraries are present, if not add them
+#ifndef  _AVR_IO_H_
 #include <avr/io.h>
 #endif
 
-#ifndef interrupt
+#ifndef _AVR_INTERRUPT_H_
 #include <avr/interrupt.h>
 #warning "Interrupts not enabled"
 #endif
-volatile uint16_t spanning = 0;
+
+volatile uint16_t potentiometerWaarde = 0;
 
 ISR(ADC_vect)
 {
-	spanning = ADC;
+	potentiometerWaarde = ADC;
 }
 
 void initVoltageMonitoring(void)
@@ -39,11 +44,17 @@ void initVoltageMonitoring(void)
 	ADCSRB = 0;
 }
 
+// GetVoltage() returns the acual voltage with a deviation of 0,05 volts
 uint16_t getVoltage(void)
 {	
-	return map(spanning, 1023, 0, 0, 500); //0 .. 1023
+	// Map the ADC to the battery voltage
+	return map(potentiometerWaarde, 0, 1023, 0, 500);
 }
 
-
-//PC3
-//DDC3
+// A map function to map the correct values to the potentiometer 
+// Note: this function is from arduino: https://www.arduino.cc/reference/en/language/functions/math/map/
+long map(long x, long in_min, long in_max, long out_min, long out_max)
+{
+	return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+/* ---------------------------------------------------- End of Voltage_monitoring.c ---------------------------------------------------- */

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
@@ -1,0 +1,49 @@
+/*
+ * Voltage_monitoring.c
+ *
+ * Created: 14-12-2023 09:15:25
+ *  Author: Julian Janssen
+ *
+ *	(R2/(R1+R2)*v) = otu
+ * (1500/(1200+1500))*9 = 5
+ *
+ *
+ */ 
+#include "Voltage_monitoring.h"
+
+#ifndef  AVR
+#include <avr/io.h>
+#endif
+
+#ifndef interrupt
+#include <avr/interrupt.h>
+#warning "Interrupts not enabled"
+#endif
+volatile uint16_t spanning = 0;
+
+ISR(ADC_vect)
+{
+	spanning = ADC;
+}
+
+void initVoltageMonitoring(void)
+{
+	// Initialize the ADC peripheral 
+	// ADMUX ADC3  MUX3..0 =  0011
+	ADMUX = (1<<REFS0) | (1<<MUX1) | (1<<MUX0);	
+	
+	// ADC Control and Status Register A
+	ADCSRA = 0b11111111; /// LAST 3 BITS ARE PRESCALER
+	
+	// Set ADC in freerunning mode
+	ADCSRB = 0;
+}
+
+uint16_t getVoltage(void)
+{	
+	return map(spanning, 1023, 0, 0, 500); //0 .. 1023
+}
+
+
+//PC3
+//DDC3

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
@@ -1,15 +1,15 @@
 /*
-* Voltage_monitoring.c
-*
-* Created: 14-12-2023 09:15:25
-*  Author: Julian Janssen
-*
-* ===== TEST RESULTS =====
-* Battery voltage:			7,7 volt
-* Voltage on divider:		4,01 volt
-* AVR measure (uint16_t):	398
-* AVR measure (REAL):		3,98 volt
-*/
+ * Voltage_monitoring.c
+ *
+ * Created: 14-12-2023 09:15:25
+ *  Author: Julian Janssen
+ *
+ * ===== TEST RESULTS =====
+ * Battery voltage:	        7,7 volt
+ * Voltage on divider:		4,01 volt
+ * AVR measure (uint16_t):	398
+ * AVR measure (REAL):		3,98 volt
+ */
 #include "Voltage_monitoring.h"
 
 // Check if these libraries are present, if not add them
@@ -32,7 +32,9 @@
 
 // uint16_t variable to store the analog converted value
 volatile uint16_t ADC_Waarde = 0;
-
+/*
+ * Initialize the ADC and start the voltage monitoring
+ */
 void initVoltageMonitoring(void)
 {
 	// Initialize the ADC peripheral
@@ -45,8 +47,9 @@ void initVoltageMonitoring(void)
 	// Set ADC in freerunning mode
 	ADCSRB = 0;
 }
-
-// GetVoltage() returns the acual voltage with a deviation of 0,05 volts
+/*
+ * GetVoltage() returns the acual voltage with a deviation of 0,05 volts
+ */
 uint16_t getVoltage(void)
 {
 	// Map the ADC to the battery voltage
@@ -54,8 +57,10 @@ uint16_t getVoltage(void)
 	return map(ADC_Waarde, MIN_ADC_VAL, MAX_ADC_VAL, MIN_VOLTAGE_VAL, MAX_VOLTAGE_VAL);
 }
 
-// A map function to map the correct values to the potentiometer
-// Note: this function is from arduino: https://www.arduino.cc/reference/en/language/functions/math/map/
+/*
+ * A map function to map the correct values to the potentiometer
+ * Note: this function is from arduino: https://www.arduino.cc/reference/en/language/functions/math/map/
+ */
 long map(long x, long in_min, long in_max, long out_min, long out_max)
 {
 	return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.c
@@ -1,17 +1,15 @@
 /*
- * Voltage_monitoring.c
- *
- * Created: 14-12-2023 09:15:25
- *  Author: Julian Janssen
- *
- * ===== TEST RESULTS =====
- * Battery voltage:			7,7 volt
- * Voltage on divider:		4,01 volt
- * AVR measure (uint16_t):	398 
- * AVR measure (REAL):		3,98 volt
- *
- *
- */ 
+* Voltage_monitoring.c
+*
+* Created: 14-12-2023 09:15:25
+*  Author: Julian Janssen
+*
+* ===== TEST RESULTS =====
+* Battery voltage:			7,7 volt
+* Voltage on divider:		4,01 volt
+* AVR measure (uint16_t):	398
+* AVR measure (REAL):		3,98 volt
+*/
 #include "Voltage_monitoring.h"
 
 // Check if these libraries are present, if not add them
@@ -24,21 +22,31 @@
 #warning "Interrupts not enabled"
 #endif
 
-volatile uint16_t potentiometerWaarde = 0;
+// Values of conversion at 5 volts (max) and 0 volts (min)
+#define MAX_ADC_VAL 1023
+#define MIN_ADC_VAL 0
+
+// Value in HUNDERDs otherwise we need to use floats
+#define MAX_VOLTAGE_VAL 500
+#define MIN_VOLTAGE_VAL 0
+
+// uint16_t variable to store the analog converted value
+volatile uint16_t ADC_Waarde = 0;
 
 ISR(ADC_vect)
 {
-	potentiometerWaarde = ADC;
+	// Save ADC value
+	ADC_Waarde = ADC;
 }
 
 void initVoltageMonitoring(void)
 {
-	// Initialize the ADC peripheral 
+	// Initialize the ADC peripheral
 	// ADMUX ADC3  MUX3..0 =  0011
-	ADMUX = (1<<REFS0) | (1<<MUX1) | (1<<MUX0);	
+	ADMUX = (1<<REFS0) | (1<<MUX1) | (1<<MUX0);
 	
 	// ADC Control and Status Register A
-	ADCSRA = 0b11111111; /// LAST 3 BITS ARE PRESCALER
+	ADCSRA = 0b11111111;
 	
 	// Set ADC in freerunning mode
 	ADCSRB = 0;
@@ -46,12 +54,13 @@ void initVoltageMonitoring(void)
 
 // GetVoltage() returns the acual voltage with a deviation of 0,05 volts
 uint16_t getVoltage(void)
-{	
+{
 	// Map the ADC to the battery voltage
-	return map(potentiometerWaarde, 0, 1023, 0, 500);
+	// standard map-values: map(ADC_Waarde, 0, 1023, 0, 500);
+	return map(ADC_Waarde, MIN_ADC_VAL, MAX_ADC_VAL, MIN_VOLTAGE_VAL, MAX_VOLTAGE_VAL);
 }
 
-// A map function to map the correct values to the potentiometer 
+// A map function to map the correct values to the potentiometer
 // Note: this function is from arduino: https://www.arduino.cc/reference/en/language/functions/math/map/
 long map(long x, long in_min, long in_max, long out_min, long out_max)
 {

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
@@ -1,9 +1,10 @@
 /*
- * Voltage_monitoring.h
- *
- * Created: 14-12-2023 09:15:12
- *  Author: Julian Janssen
- */ 
+* Voltage_monitoring.h
+*
+* Created: 14-12-2023 09:15:12
+*  Author: Julian Janssen
+*/
+
 #include <avr/io.h>
 
 #ifndef VOLTAGE_MONITORING_H_

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
@@ -1,0 +1,16 @@
+/*
+ * Voltage_monitoring.h
+ *
+ * Created: 14-12-2023 09:15:12
+ *  Author: Julian Janssen
+ */ 
+#include <avr/io.h>
+
+#ifndef VOLTAGE_MONITORING_H_
+#define VOLTAGE_MONITORING_H_
+
+void initVoltageMonitoring(void);
+uint16_t getVoltage(void);
+
+
+#endif /* VOLTAGE_MONITORING_H_ */

--- a/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
+++ b/RobotCar/Functions/Voltage_monitoring/Voltage_monitoring.h
@@ -11,6 +11,7 @@
 
 void initVoltageMonitoring(void);
 uint16_t getVoltage(void);
+long map(long x, long in_min, long in_max, long out_min, long out_max);
 
 
 #endif /* VOLTAGE_MONITORING_H_ */

--- a/RobotCar/RobotCar.cproj
+++ b/RobotCar/RobotCar.cproj
@@ -158,6 +158,12 @@
     <Compile Include="Functions\Pinmap.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="Functions\Voltage_monitoring\Voltage_monitoring.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Functions\Voltage_monitoring\Voltage_monitoring.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="main.c">
       <SubType>compile</SubType>
     </Compile>
@@ -166,6 +172,7 @@
     <Folder Include="Functions" />
     <Folder Include="Functions\Buttons\" />
     <Folder Include="Functions\millis" />
+    <Folder Include="Functions\Voltage_monitoring" />
   </ItemGroup>
   <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
 </Project>

--- a/RobotCar/RobotCar.cproj
+++ b/RobotCar/RobotCar.cproj
@@ -41,7 +41,7 @@
       </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.medbg</avrtool>
-    <avrtoolserialnumber>ATML2323052700006640</avrtoolserialnumber>
+    <avrtoolserialnumber>ATML2323052700006729</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0x1E950F</avrdeviceexpectedsignature>
     <com_atmel_avrdbg_tool_medbg>
       <ToolOptions>
@@ -50,7 +50,7 @@
         <InterfaceName>debugWIRE</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.medbg</ToolType>
-      <ToolNumber>ATML2323052700006640</ToolNumber>
+      <ToolNumber>ATML2323052700006729</ToolNumber>
       <ToolName>mEDBG</ToolName>
     </com_atmel_avrdbg_tool_medbg>
     <avrtoolinterface>debugWIRE</avrtoolinterface>

--- a/RobotCar/main.c
+++ b/RobotCar/main.c
@@ -2,17 +2,20 @@
  * RobotCar.c
  *
  * Created: 10/23/2023 7:16:03 PM
- * Author : Sjoerd
+ * Authors : Sjoerd van de Wege & Julian Janssen &
+ *			 Ayman el Barakat & Joep Spaanjaars
  */
-
-#include "Uart/Uart.h"
 #include <avr/io.h>
+#include <avr/interrupt.h>
+#include <util/delay.h>
+
+//Robot-auto specific libraries
+#include "Uart/Uart.h"
 #include "Functions/Appinfo.h"
 #include "Functions/millis/millis.h"
 #include "Functions/Buttons/mode_select.h"
 #include "Functions/Voltage_monitoring/Voltage_monitoring.h"
 
-#include <util/delay.h>
 int main(void)
 {
 	IO_init();

--- a/RobotCar/main.c
+++ b/RobotCar/main.c
@@ -11,13 +11,23 @@
 #include "Functions/millis/millis.h"
 #include "Functions/Buttons/mode_select.h"
 
+#include "Functions/Voltage_monitoring/Voltage_monitoring.h"
+
+#include <util/delay.h>
 int main(void)
 {
 	IO_init();
 	millis_init();
+	initVoltageMonitoring();
 	
+	sei();
+	
+	volatile uint16_t sapning=0;
     while (1) 
     {
+		_delay_ms(1000);
 		readSwitches();
+		sapning = getVoltage();
+		
     }
 }

--- a/RobotCar/main.c
+++ b/RobotCar/main.c
@@ -7,7 +7,6 @@
  */
 #include <avr/io.h>
 #include <avr/interrupt.h>
-#include <util/delay.h>
 
 //Robot-auto specific libraries
 #include "Uart/Uart.h"
@@ -21,15 +20,10 @@ int main(void)
 	IO_init();
 	millis_init();
 	initVoltageMonitoring();
-	
 	sei();
-	
-	volatile uint16_t spanning = 0;
+
     while (1) 
     {
-		_delay_ms(1000);
-		readSwitches();
-		spanning = getVoltage();
-		
+		readSwitches();		
     }
 }

--- a/RobotCar/main.c
+++ b/RobotCar/main.c
@@ -10,7 +10,6 @@
 #include "Functions/Appinfo.h"
 #include "Functions/millis/millis.h"
 #include "Functions/Buttons/mode_select.h"
-
 #include "Functions/Voltage_monitoring/Voltage_monitoring.h"
 
 #include <util/delay.h>
@@ -22,12 +21,12 @@ int main(void)
 	
 	sei();
 	
-	volatile uint16_t sapning=0;
+	volatile uint16_t spanning = 0;
     while (1) 
     {
 		_delay_ms(1000);
 		readSwitches();
-		sapning = getVoltage();
+		spanning = getVoltage();
 		
     }
 }


### PR DESCRIPTION
### Spanning monitor is nu afgerond

Door de functie `getVoltage()` aan te roepen krijg je de werkelijke spanning dat uit de voltage divider komt.

Dit is tevens getest met een multimeter. De afwijking is ± 0,05 volt. De stroom naar de AVR stroomt 3,4µA, op 7,70 volt accuspanning.